### PR TITLE
FIX: SQLite3Query::seek() failed to return a record

### DIFF
--- a/code/SQLite3Query.php
+++ b/code/SQLite3Query.php
@@ -47,10 +47,10 @@ class SQLite3Query extends Query
     {
         $this->handle->reset();
         $i=0;
-        while ($i < $row && $row = @$this->handle->fetchArray()) {
+        while ($i <= $row && $result = @$this->handle->fetchArray(SQLITE3_ASSOC)) {
             $i++;
         }
-        return true;
+        return $result;
     }
 
     /**
@@ -58,6 +58,7 @@ class SQLite3Query extends Query
      */
     public function numRecords()
     {
+        $this->handle->reset();
         $c=0;
         while ($this->handle->fetchArray()) {
             $c++;


### PR DESCRIPTION
This brings `SQLite3Query::seek()` in line with other drivers - `Query::seek()` should seek to the given offset, and then return the record.

The addition to `numRecords()` is because without it, `seek()` can interfere with the row count by changing the pointer, so we need go back to the first row before we attempt to count them all.