### PR TITLE
Expose as vendor module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "silverstripe/sqlite3",
 	"description": "Adds SQLite3 support to SilverStripe",
-	"type": "silverstripe-module",
+	"type": "silverstripe-vendormodule",
 	"keywords": ["silverstripe", "sqlite3", "database"],
 	"authors": [
 		{
@@ -14,7 +14,8 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": "~4.0"
+		"silverstripe/framework": "~4.0",
+		"silverstripe/vendor-plugin": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8"


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405

```
composer config repositories.sqlite3 vcs https://github.com/open-sausages/silverstripe-sqlite3.git
composer require "silverstripe/sqlite3:dev-pulls/2/vendorise-me-baby as 2.0.x-dev"
```