### PR TITLE
return 0 for non iterable results

### DIFF
--- a/code/SQLite3Query.php
+++ b/code/SQLite3Query.php
@@ -58,6 +58,11 @@ class SQLite3Query extends Query
      */
     public function numRecords()
     {
+        // Some queries are not iterable using fetchArray like CREATE statement
+        if (!$this->handle->numColumns()) {
+            return 0;
+        }
+        
         $this->handle->reset();
         $c=0;
         while ($this->handle->fetchArray()) {


### PR DESCRIPTION
If there are no columns, it's not a iterable result set and we can return 0. This fixes issues with things like CREATE statement.