### PR TITLE
Escape enum default death

### DIFF
--- a/code/SQLite3Database.php
+++ b/code/SQLite3Database.php
@@ -485,24 +485,76 @@ class SQLite3Database extends Database
 
     public function transactionRollback($savepoint = false)
     {
+        // Named transaction
         if ($savepoint) {
             $this->query("ROLLBACK TO $savepoint;");
-        } else {
-            --$this->transactionNesting;
-            if ($this->transactionNesting > 0) {
-                $this->transactionRollback('NESTEDTRANSACTION' . $this->transactionNesting);
-            } else {
-                $this->query('ROLLBACK;');
-            }
+            return true;
         }
+
+        // Fail if transaction isn't available
+        if (!$this->transactionNesting) {
+            return false;
+        }
+
+        --$this->transactionNesting;
+        if ($this->transactionNesting > 0) {
+            $this->transactionRollback('NESTEDTRANSACTION' . $this->transactionNesting);
+        } else {
+            $this->query('ROLLBACK;');
+        }
+        return true;
+    }
+
+    public function transactionDepth()
+    {
+        return $this->transactionNesting;
     }
 
     public function transactionEnd($chain = false)
     {
+        // Fail if transaction isn't available
+        if (!$this->transactionNesting) {
+            return false;
+        }
         --$this->transactionNesting;
         if ($this->transactionNesting <= 0) {
             $this->transactionNesting = 0;
             $this->query('COMMIT;');
+        }
+        return true;
+    }
+
+    /**
+     * In error condition, set transactionNesting to zero
+     */
+    protected function resetTransactionNesting()
+    {
+        $this->transactionNesting = 0;
+    }
+
+    public function query($sql, $errorLevel = E_USER_ERROR)
+    {
+        $this->inspectQuery($sql);
+        return parent::query($sql, $errorLevel);
+    }
+
+    public function preparedQuery($sql, $parameters, $errorLevel = E_USER_ERROR)
+    {
+        $this->inspectQuery($sql);
+        return parent::preparedQuery($sql, $parameters, $errorLevel);
+    }
+
+    /**
+     * Inspect a SQL query prior to execution
+     *
+     * @param string $sql
+     */
+    protected function inspectQuery($sql)
+    {
+        // Any DDL discards transactions.
+        $isDDL = $this->getConnector()->isQueryDDL($sql);
+        if ($isDDL) {
+            $this->resetTransactionNesting();
         }
     }
 

--- a/code/SQLite3SchemaManager.php
+++ b/code/SQLite3SchemaManager.php
@@ -2,10 +2,11 @@
 
 namespace SilverStripe\SQLite;
 
+use Exception;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\Connect\DBSchemaManager;
-use Exception;
+use SQLite3;
 
 /**
  * SQLite schema manager class
@@ -540,7 +541,18 @@ class SQLite3SchemaManager extends DBSchemaManager
 
         // Set default
         if (!empty($values['default'])) {
-            $default = str_replace(array('"', "'", "\\", "\0"), "", $values['default']);
+            /*
+            On escaping strings:
+
+            https://www.sqlite.org/lang_expr.html
+            "A string constant is formed by enclosing the string in single quotes ('). A single quote within
+            the string can be encoded by putting two single quotes in a row - as in Pascal. C-style escapes
+            using the backslash character are not supported because they are not standard SQL."
+
+            Also, there is a nifty PHP function for this. However apparently one must still be cautious of
+            the null character ('\0' or 0x0), as per https://bugs.php.net/bug.php?id=63419
+            */
+            $default = SQLite3::escapeString(str_replace("\0", "", $values['default']));
             return "TEXT DEFAULT '$default'";
         } else {
             return 'TEXT';

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,11 @@
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"
 	},
+    "extra": {
+		"branch-alias": {
+			"2.x-dev": "2.2.x-dev"
+		}
+	},
 	"autoload": {
 		"psr-4": {
 			"SilverStripe\\SQLite\\": "code/"


### PR DESCRIPTION
Fixes #45 
Allows SQLite to support Enum values with the backslash character (`\`) in them as a default - e.g. `DBClassName` used for Polymorphic relationships.