### PR TITLE
FIX preserve enum values with correct escaping

### DIFF
--- a/code/SQLite3SchemaManager.php
+++ b/code/SQLite3SchemaManager.php
@@ -2,10 +2,11 @@
 
 namespace SilverStripe\SQLite;
 
+use Exception;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\Connect\DBSchemaManager;
-use Exception;
+use SQLite3;
 
 /**
  * SQLite schema manager class
@@ -540,7 +541,18 @@ class SQLite3SchemaManager extends DBSchemaManager
 
         // Set default
         if (!empty($values['default'])) {
-            $default = str_replace(array('"', "'", "\\", "\0"), "", $values['default']);
+            /*
+            On escaping strings:
+
+            https://www.sqlite.org/lang_expr.html
+            "A string constant is formed by enclosing the string in single quotes ('). A single quote within
+            the string can be encoded by putting two single quotes in a row - as in Pascal. C-style escapes
+            using the backslash character are not supported because they are not standard SQL."
+
+            Also, there is a nifty PHP function for this. However apparently one must still be cautious of
+            the null character ('\0' or 0x0), as per https://bugs.php.net/bug.php?id=63419
+            */
+            $default = SQLite3::escapeString(str_replace("\0", "", $values['default']));
             return "TEXT DEFAULT '$default'";
         } else {
             return 'TEXT';


### PR DESCRIPTION
Fixes #45 
Allows SQLite to support Enum values with the backslash character (`\`) in them as a default - e.g. `DBClassName` used for Polymorphic relationships.

Enum values are themselves enumerated in sqlite as they are not supported
as a type. This leads to values being stored in their own table, and a
regular TEXT field being used in a MySQL ENUM's stead. The default value
for this field was being escaped with custom string replacement, and
erroneously relacing the backslash (a redundant operation). This lead
to invalid Fully Qualified Class Names in SilverStripe 4, which is a
required trait for polymorphic relationships. As a result any polymorphic
relationship not set on first write would then proceed to cause an execution
error the next time the dataobject with the relationship was fetched from
the database. By using the PHP supplied escape function for SQLite3 we can
avoid this, and restore functionality.

Relevant section of SQLite documentation to justify the removal of escaping
various characters, such as the backslash:

A string constant is formed by enclosing the string in single quotes (').
A single quote within the string can be encoded by putting two single quotes
in a row - as in Pascal. C-style escapes using the backslash character are
not supported because they are not standard SQL.

https://www.sqlite.org/lang_expr.html