### PR TITLE
FIX Tighten transactions

### DIFF
--- a/code/SQLite3Database.php
+++ b/code/SQLite3Database.php
@@ -611,7 +611,7 @@ class SQLite3Database extends Database
 
     /**
      * Inspect a SQL query prior to execution
-     * @deprecated 2..3
+     * @deprecated 2.2.0:3.0.0
      * @param string $sql
      */
     protected function inspectQuery($sql)

--- a/code/SQLite3Database.php
+++ b/code/SQLite3Database.php
@@ -491,7 +491,7 @@ class SQLite3Database extends Database
 
     /**
      * Fetch the name of the most recent savepoint
-     * 
+     *
      * @return string
      */
     protected function getTransactionSavepointName()

--- a/code/SQLite3SchemaManager.php
+++ b/code/SQLite3SchemaManager.php
@@ -286,7 +286,7 @@ class SQLite3SchemaManager extends DBSchemaManager
 
         // Then alter the table column
         $database = $this->database;
-        $database->withTransaction(function() use ($database, $queries, $indexList) {
+        $database->withTransaction(function () use ($database, $queries, $indexList) {
             foreach ($queries as $query) {
                 $database->query($query . ';');
             }
@@ -330,7 +330,7 @@ class SQLite3SchemaManager extends DBSchemaManager
 
         // Then alter the table column
         $database = $this->database;
-        $database->withTransaction(function() use ($database, $queries) {
+        $database->withTransaction(function () use ($database, $queries) {
             foreach ($queries as $query) {
                 $database->query($query . ';');
             }
@@ -429,6 +429,15 @@ class SQLite3SchemaManager extends DBSchemaManager
     public function indexKey($table, $index, $spec)
     {
         return $this->buildSQLiteIndexName($table, $index);
+    }
+
+    protected function convertIndexSpec($indexSpec)
+    {
+        $supportedIndexTypes = ['index', 'unique'];
+        if (isset($indexSpec['type']) && !in_array($indexSpec['type'], $supportedIndexTypes)) {
+            $indexSpec['type'] = 'index';
+        }
+        return parent::convertIndexSpec($indexSpec);
     }
 
     public function indexList($table)

--- a/code/SQLite3SchemaManager.php
+++ b/code/SQLite3SchemaManager.php
@@ -275,21 +275,22 @@ class SQLite3SchemaManager extends DBSchemaManager
         }
 
         $queries = array(
-            "BEGIN TRANSACTION",
             "CREATE TABLE \"{$tableName}_alterfield_{$fieldName}\"(" . implode(',', $newColsSpec) . ")",
             "INSERT INTO \"{$tableName}_alterfield_{$fieldName}\" SELECT {$fieldNameList} FROM \"$tableName\"",
             "DROP TABLE \"$tableName\"",
             "ALTER TABLE \"{$tableName}_alterfield_{$fieldName}\" RENAME TO \"$tableName\"",
-            "COMMIT"
         );
 
         // Remember original indexes
         $indexList = $this->indexList($tableName);
 
         // Then alter the table column
-        foreach ($queries as $query) {
-            $this->query($query.';');
-        }
+        $database = $this->database;
+        $database->withTransaction(function() use ($database, $queries, $indexList) {
+            foreach ($queries as $query) {
+                $database->query($query . ';');
+            }
+        });
 
         // Recreate the indexes
         foreach ($indexList as $indexName => $indexSpec) {
@@ -318,21 +319,22 @@ class SQLite3SchemaManager extends DBSchemaManager
         $oldColsStr = implode(',', $oldCols);
         $newColsSpecStr = implode(',', $newColsSpec);
         $queries = array(
-            "BEGIN TRANSACTION",
             "CREATE TABLE \"{$tableName}_renamefield_{$oldName}\" ({$newColsSpecStr})",
             "INSERT INTO \"{$tableName}_renamefield_{$oldName}\" SELECT {$oldColsStr} FROM \"$tableName\"",
             "DROP TABLE \"$tableName\"",
             "ALTER TABLE \"{$tableName}_renamefield_{$oldName}\" RENAME TO \"$tableName\"",
-            "COMMIT"
         );
 
         // Remember original indexes
         $oldIndexList = $this->indexList($tableName);
 
         // Then alter the table column
-        foreach ($queries as $query) {
-            $this->query($query.';');
-        }
+        $database = $this->database;
+        $database->withTransaction(function() use ($database, $queries) {
+            foreach ($queries as $query) {
+                $database->query($query . ';');
+            }
+        });
 
         // Recreate the indexes
         foreach ($oldIndexList as $indexName => $indexSpec) {


### PR DESCRIPTION
Fixes #48 

Thanks to @dhensby's work to add (nested) transaction support, there were only a few outstanding issues to tidy up in order to get tests to run without error (caused by this module).

The crux of the issue was that table alterations were using transactions but not via the API for it, which was causing issues.
Some inspection to reset nesting levels if a query contained DDL was causing nesting errors - now removed and the empty method deprecated.

The logic around transactions is generally tidied up by introducing a few `protected` methods and supporting variables.