### PR TITLE
Added quotes to values in connectors.yml

### DIFF
--- a/_config/connectors.yml
+++ b/_config/connectors.yml
@@ -5,28 +5,28 @@ SilverStripe\Core\Injector\Injector:
   SQLite3PDODatabase:
     class: SilverStripe\SQLite\SQLite3Database
     properties:
-      connector: %$PDOConnector
-      schemaManager: %$SQLite3SchemaManager
-      queryBuilder: %$SQLite3QueryBuilder
+      connector: '%$PDOConnector'
+      schemaManager: '%$SQLite3SchemaManager'
+      queryBuilder: '%$SQLite3QueryBuilder'
   SQLite3Database:
     class: SilverStripe\SQLite\SQLite3Database
     properties:
-      connector: %$SQLite3Connector
-      schemaManager: %$SQLite3SchemaManager
-      queryBuilder: %$SQLite3QueryBuilder
+      connector: '%$SQLite3Connector'
+      schemaManager: '%$SQLite3SchemaManager'
+      queryBuilder: '%$SQLite3QueryBuilder'
 # Legacy connector names
   SQLiteDatabase:
     class: SilverStripe\SQLite\SQLite3Database
     properties:
-      connector: %$SQLite3Connector
-      schemaManager: %$SQLite3SchemaManager
-      queryBuilder: %$SQLite3QueryBuilder
+      connector: '%$SQLite3Connector'
+      schemaManager: '%$SQLite3SchemaManager'
+      queryBuilder: '%$SQLite3QueryBuilder'
   SQLitePDODatabase:
     class: SilverStripe\SQLite\SQLite3Database
     properties:
-      connector: %$SQLite3Connector
-      schemaManager: %$SQLite3SchemaManager
-      queryBuilder: %$SQLite3QueryBuilder
+      connector: '%$SQLite3Connector'
+      schemaManager: '%$SQLite3SchemaManager'
+      queryBuilder: '%$SQLite3QueryBuilder'
   SQLite3Connector:
     class: SilverStripe\SQLite\SQLite3Connector
     type: prototype


### PR DESCRIPTION
Fixes #57 by adding quotes to values starting with `%` in `connectors.yml`.