### PR TITLE
Override transaction mode support check method

### DIFF
--- a/code/SQLite3Database.php
+++ b/code/SQLite3Database.php
@@ -460,6 +460,19 @@ class SQLite3Database extends Database
         return version_compare($this->getVersion(), '3.6', '>=');
     }
 
+    /**
+     * Does this database support transaction modes?
+     *
+     * SQLite doesn't support transaction modes.
+     *
+     * @param string $mode
+     * @return bool
+     */
+    public function supportsTransactionMode(string $mode): bool
+    {
+        return false;
+    }
+
     public function supportsExtensions($extensions = array('partitions', 'tablespaces', 'clustering'))
     {
         if (isset($extensions['partitions'])) {


### PR DESCRIPTION
As transaction modes are not supported by SQLite, override the check method.

This is an accompanying PR to https://github.com/silverstripe/silverstripe-framework/pull/9240 to support SQLite test suite running correctly.