### PR TITLE
prevent php 8 complaining about null values

### DIFF
--- a/code/SQLite3Connector.php
+++ b/code/SQLite3Connector.php
@@ -170,7 +170,7 @@ class SQLite3Connector extends DBConnector
 
     public function escapeString($value)
     {
-        return $this->dbConn->escapeString((string)$value);
+        return $this->dbConn->escapeString($value ?? '');
     }
 
     public function selectDatabase($name)

--- a/code/SQLite3Connector.php
+++ b/code/SQLite3Connector.php
@@ -48,7 +48,7 @@ class SQLite3Connector extends DBConnector
     public function getLastError()
     {
         $message = $this->dbConn->lastErrorMsg();
-        return $message === 'not an error' ? null : $message;
+        return $message === 'not an error' ? '' : $message;
     }
 
     public function getSelectedDatabase()

--- a/code/SQLite3Connector.php
+++ b/code/SQLite3Connector.php
@@ -48,7 +48,7 @@ class SQLite3Connector extends DBConnector
     public function getLastError()
     {
         $message = $this->dbConn->lastErrorMsg();
-        return $message === 'not an error' ? '' : $message;
+        return $message === 'not an error' ? null : $message;
     }
 
     public function getSelectedDatabase()

--- a/code/SQLite3Connector.php
+++ b/code/SQLite3Connector.php
@@ -170,7 +170,7 @@ class SQLite3Connector extends DBConnector
 
     public function escapeString($value)
     {
-        return $this->dbConn->escapeString($value);
+        return $this->dbConn->escapeString((string)$value);
     }
 
     public function selectDatabase($name)


### PR DESCRIPTION
- Fix Deprecated: SQLite3::escapeString(): Passing null to parameter # 1 ($string) of type string is deprecated
- Fix Deprecated: preg_match(): Passing null to parameter # 2 ($subject) of type string is deprecated